### PR TITLE
add scripts to back and front end package.jsons (reseed and quick_installs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,14 @@
 + CSS3
 
 ## Setup
-+ To run this project, instantiate and seed the database with PostgreSQL:
++ To run this project, using PostgreSQL and npm, install the seeded database and server:
   ```
-  $ cd backend/db
-  $ psql -f capstone_project_db.sql
+  $ cd backend
+  $ npm run quick_install
   ```
-+ Second, install the server locally using npm:
-  ```
-  $ cd ..
-  $ npm install
-  $ npm start
-  ```
-+ In another terminal instance install the frontend locally using npm:
++ Then in a second terminal instance install the frontend locally using npm:
   ```
   $ cd ../frontend
-  $ npm install
-  $ npm start
+  $ npm run quick_install
   ```
 + The site app will be found at: http://localhost:3008/

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "dev": "nodemon ./bin/www"
+    "dev": "nodemon ./bin/www",
+    "reseed": "psql -f db/seed.sql",
+    "quick_install": "psql -f db/seed.sql && npm install && npm start"
   },
   "dependencies": {
     "aws-sdk": "^2.647.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "start": "PORT=3008 react-scripts start",
+    "quick_install": "npm install && npm start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
## Description
added quick_install scripts to both backend and frontend folders
added reseed script to backend folder

## Motivation and Context
makes reseed easier. simpler documented quick install = more likelihood someone will install and try out app

## How Has This Been Tested?
ran scripts in node with no errors or issues

## Screenshots (if appropriate):

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings