### PR TITLE
add ON UPDATE CASCADE to foreign key references to users_data(user_email)

### DIFF
--- a/backend/db/seed.sql
+++ b/backend/db/seed.sql
@@ -35,14 +35,14 @@ CREATE TABLE administration (
     a_id SERIAL PRIMARY KEY,
     a_first_name VARCHAR (30) NOT NULL,
     a_last_name VARCHAR (30) NOT NULL,
-    a_email VARCHAR (50) REFERENCES users_data(user_email)
+    a_email VARCHAR (50) REFERENCES users_data(user_email) ON UPDATE CASCADE
 );
 
 CREATE TABLE volunteers (
     v_id SERIAL PRIMARY KEY,
     v_first_name VARCHAR (30) NOT NULL,
     v_last_name VARCHAR (30) NOT NULL,
-    v_email VARCHAR (50) REFERENCES users_data(user_email),
+    v_email VARCHAR (50) REFERENCES users_data(user_email) ON UPDATE CASCADE,
     confirmed BOOLEAN NOT NULL DEFAULT FALSE,
     active BOOLEAN NOT NULL DEFAULT TRUE,
     v_picture VARCHAR,
@@ -66,7 +66,7 @@ CREATE TABLE fellows (
     f_id SERIAL PRIMARY KEY,
     f_first_name VARCHAR (30) NOT NULL,
     f_last_name VARCHAR (30) NOT NULL,
-    f_email VARCHAR (50) REFERENCES users_data(user_email),
+    f_email VARCHAR (50) REFERENCES users_data(user_email) ON UPDATE CASCADE,
     f_picture VARCHAR,
     f_bio VARCHAR,
     f_linkedin VARCHAR (150),


### PR DESCRIPTION
## Description
added ON UPDATE CASCADE to foreign key references to users_data(user_email) in admin, volunteers, and fellows tables

## Motivation and Context
this ensures if the users_data.user_email is changed, then the change cascades to the relevant table automatically and immediately

## How Has This Been Tested?
file reseed triggers no errors

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
