### PR TITLE
fix and refactor processInput bool switch

### DIFF
--- a/backend/helpers/processInput.js
+++ b/backend/helpers/processInput.js
@@ -57,10 +57,13 @@ const processInput = (input, category, inputName, limit) => {
 
     // for booleans
     case "bool":
-        if (!input || !input.trim() || (input.toLowerCase() !== "true" && input.toLowerCase() !== "false")) {
-          throw new Error(`404__error: invalid boolean input ${inputName} - ${input}`);
+        // currently undefineds will respond as FAIL
+        if (typeof input === "boolean") return input; // lets actual booleans through
+        if (input && input.trim()) {
+          if (input.trim().toLowerCase() === "true" || input === true) return true;
+          if (input.trim().toLowerCase() === "false" || input === false) return false;
         }
-        return input.trim();
+        throw new Error(`404__error: invalid boolean input`);
 
     default:
         throw new Error(`500__error: you're not supposed to be here. input category unknown`);

--- a/backend/helpers/processInput.js
+++ b/backend/helpers/processInput.js
@@ -57,11 +57,11 @@ const processInput = (input, category, inputName, limit) => {
 
     // for booleans
     case "bool":
-        // currently undefineds will respond as FAIL
+        // currently undefined will respond as FAIL
         if (typeof input === "boolean") return input; // lets actual booleans through
         if (input && input.trim()) {
-          if (input.trim().toLowerCase() === "true" || input === true) return true;
-          if (input.trim().toLowerCase() === "false" || input === false) return false;
+          if (input.trim().toLowerCase() === "true") return true;
+          if (input.trim().toLowerCase() === "false") return false;
         }
         throw new Error(`404__error: invalid boolean input`);
 


### PR DESCRIPTION
## Description
edited processInput bool switch to 
1-allow boolean type inputs through, and 
2-return boolean type responses

## Motivation and Context
refactored to preserve boolean types and return boolean types. booleans wanted in, booleans only going out unless error.

## How Has This Been Tested?
Postman queries sending req to endpoint wanting bool, and postman client expecting bool response

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings