### PR TITLE
refactor and revise handleError to log full error including stack, cap varchar at 65536

### DIFF
--- a/backend/helpers/handleError.js
+++ b/backend/helpers/handleError.js
@@ -13,7 +13,7 @@ example:
 
 const errorResponse = (res, code, err) => {
   const errorMsg = err.message;
-  err.message = err.message + "\nStack:"
+  err.message = err.message + "\nDetails:"
   console.log(err); // log for developer
   res.status(code);
   res.json({

--- a/backend/helpers/handleError.js
+++ b/backend/helpers/handleError.js
@@ -5,25 +5,26 @@ Server Error Handling Helper | Capstone App (Pursuit Volunteer Mgr)
 
 USAGE
 to instantiate custom error, use format:
-  throw new Error(`<error code>__error: <msg>`);
+  throw new Error(`<error code>__<msg>`);
 example:
-  throw new Error(`404__error: volunteer ${volunteerId} not found`);
+  throw new Error(`404__volunteer ${volunteerId} not found`);
 */
 
 
-const errorResponse = (res, code, errorMsg) => {
-  console.log('Error message: ', errorMsg, '\n');   // log for developer
+const errorResponse = (res, code, err) => {
+  const errorMsg = err.message;
+  err.message = err.message + "\nStack:"
+  console.log(err); // log for developer
   res.status(code);
   res.json({
       status: "fail",
-      message: errorMsg,
+      message: "Error: " + errorMsg,
       payload: null
   });
 }
 
 
 const handleError = (err, req, res, next) => {
-  console.log('Error: ', err, '\n');
   /* STAGE 1/5:
   Per documentation, checking for present headers and if so, pass to default Express error handler
   https://expressjs.com/en/guide/error-handling.html#the-default-error-handler
@@ -35,11 +36,11 @@ const handleError = (err, req, res, next) => {
 
     /* STAGE 2/5: intercept database response errors and customize error msgs */
     if (err.code === "23503") {
-      err.message = `403__error: reference error in database lookup`;
+      err.message = `403__reference error in database lookup`;
     } else if (err.code === "23505" && err.message.includes("violates unique constraint")) {
-      err.message = `403__error: at least one unique datapoint of record already exists`;
+      err.message = `403__at least one unique datapoint of record already exists`;
     } else if (err.message === "No data returned from the query.") {
-      err.message = `404__error: specific record does not exist`;
+      err.message = `404__specific record does not exist`;
     }
 
     /* STAGE 3/5: split custom error.messages for relevant http code */
@@ -47,16 +48,14 @@ const handleError = (err, req, res, next) => {
 
     /* STAGE 4/5: if "__" wasn't found, error was not thrown from a customized instance and will send response here */
     if (msg === code) {
-      errorResponse(res, 500, `(back) error: ${msg}`);
+      err.message = `(500) ${msg}`;
+      errorResponse(res, 500, err);
     } else {
 
       /* STAGE 5/5: custom error received. format and send response */
-      res.status(parseInt(code));
-      const codeClass = parseInt(code).toString()[0];
-      const errorLocation = codeClass === '4'
-        ? "(front)"
-        : "(back)";
-      errorResponse(res, code, `${errorLocation} ${msg}`);
+      code = parseInt(code);
+      err.message = `(${code}) ${msg}`;
+      errorResponse(res, code, err);
     }
   }
 };

--- a/backend/helpers/processInput.js
+++ b/backend/helpers/processInput.js
@@ -59,7 +59,7 @@ const processInput = (input, category, inputName, limit) => {
     case "bool":
         // currently undefined will respond as FAIL
         if (typeof input === "boolean") return input; // lets actual booleans through
-        if (input && input.trim()) {
+        if (input && input.trim()) {  // for string bools like req.search params
           if (input.trim().toLowerCase() === "true") return true;
           if (input.trim().toLowerCase() === "false") return false;
         }

--- a/backend/helpers/processInput.js
+++ b/backend/helpers/processInput.js
@@ -10,23 +10,23 @@ patch- === translates empty input to undefined, in prep for patch routes
 */
 
 
-const varcharCheck = (input, softHardOrPatch, inputName, maxLengthNum = Infinity) => {
+const varcharCheck = (input, softHardOrPatch, inputName, maxLengthNum = 65536) => {
   /* STAGE 1/3: check for and handle empty inputs */
   if (!input || !input.trim()) {
     switch (softHardOrPatch) {
       case "hard":  // empty input is REJECTED
-        throw new Error(`400__error: invalid empty ${inputName} input`);
+        throw new Error(`400__invalid empty ${inputName} input`);
       case "soft":  // empty input becomes EMPTY STRING
         return "";
       case "patch":  // empty input returns UNDEFINED
         return;
       default:
-        throw new Error(`500__error: unknown varchar type sent to check function`);
+        throw new Error(`500__unknown varchar type sent to check function`);
     }
   }
   /* STAGE 2/3: check input length against specified varchar limit */
   if (input.trim().length > maxLengthNum) {
-    throw new Error(`400__error: ${inputName} is longer than ${maxLengthNum} allowed`);
+    throw new Error(`400__${inputName} is longer than ${maxLengthNum} allowed`);
   }
   /* STAGE 3/3: all checks have passed, return trimmed input */
   return input.trim();
@@ -39,7 +39,7 @@ const processInput = (input, category, inputName, limit) => {
     // for numbers that are ids
     case "idNum":
         if (isNaN(parseInt(input)) || input.toString().length !== parseInt(input).toString().length) {
-          throw new Error(`400__error: invalid numerical ${inputName} input`);
+          throw new Error(`400__invalid numerical ${inputName} input`);
         }
         return parseInt(input);
 
@@ -59,14 +59,14 @@ const processInput = (input, category, inputName, limit) => {
     case "bool":
         // currently undefined will respond as FAIL
         if (typeof input === "boolean") return input; // lets actual booleans through
-        if (input && input.trim()) {  // for string bools like req.search params
+        if (input && input.trim()) { // for checking string type booleans like req.search bool params
           if (input.trim().toLowerCase() === "true") return true;
           if (input.trim().toLowerCase() === "false") return false;
         }
-        throw new Error(`404__error: invalid boolean input`);
+        throw new Error(`404__invalid boolean input`);
 
     default:
-        throw new Error(`500__error: you're not supposed to be here. input category unknown`);
+        throw new Error(`500__you're not supposed to be here. input category unknown`);
   }
 }
 


### PR DESCRIPTION
## Description
refactor and revise handleError to log full error including stack, 
display error code now instead of front/back label in error messages,
change varchar cap to 65536 from Infinity

## Motivation and Context
Forgot to log error stack, more specificity with error codes shown and front/back labels become redundant. cap on varchars because why not. 65k characters is more than enough. probably should cap even lower

## How Has This Been Tested?
Postman with error expected queries, and with successful queries

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings