### PR TITLE
Amin/backend/auth/secure add admin

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -7,6 +7,7 @@ const session = require('express-session');
 const passport = require('./auth/passport');
 
 const authRouter = require('./routes/auth');
+const adminRouter = require('./routes/admin');
 const fellowsRouter = require('./routes/fellows');
 const volunteerRouter = require('./routes/volunteers');
 const timeRouter = require('./routes/time');
@@ -33,6 +34,7 @@ app.use(passport.session());
 
 
 app.use('/api/auth', authRouter);
+app.use('/api/admin', checkUserLogged, adminRouter);
 app.use('/api/fellows', /*checkUserLogged,*/ fellowsRouter);
 app.use('/api/volunteers', /*checkUserLogged,*/ volunteerRouter);
 app.use('/api/time', /*checkUserLogged,*/ timeRouter);

--- a/backend/queries/admin.js
+++ b/backend/queries/admin.js
@@ -8,7 +8,7 @@ const getAdminByEmail = async (email) => {
 
 const addAdmin = async (firstName, lastName, email, newPassword, oldPassword) => {
     // Update the password of the new admin whom already registered into the users_data
-    const registeredUser = await userQueries.updatePassword(email, newPassword, );
+    const registeredUser = await userQueries.updatePassword(email, newPassword);
 
     const insertQuery = `
         INSERT INTO administration (a_first_name, a_last_name, a_email) VALUES

--- a/backend/queries/admin.js
+++ b/backend/queries/admin.js
@@ -6,8 +6,9 @@ const getAdminByEmail = async (email) => {
     return await db.one('SELECT * FROM administration WHERE a_email = $1', email)
 }
 
-const addAdmin = async (firstName, lastName, email, password) => {
-    const registeredUser = await userQueries.addUser(email, password, 'admin');
+const addAdmin = async (firstName, lastName, email, newPassword, oldPassword) => {
+    // Update the password of the new admin whom already registered into the users_data
+    const registeredUser = await userQueries.updatePassword(email, newPassword, );
 
     const insertQuery = `
         INSERT INTO administration (a_first_name, a_last_name, a_email) VALUES
@@ -16,8 +17,8 @@ const addAdmin = async (firstName, lastName, email, password) => {
     try {
         return await db.one(insertQuery, [firstName, lastName, email])
     } catch (err) {
-        if (registeredUser) {
-            userQueries.deleteUser(email);
+        if (registeredUser) { // if adding the new admin to administration table fails, the password gets reset
+            userQueries.updatePassword(email, oldPassword);
         }
         throw err;
     }

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const router = express.Router();
+
+const { hashPassword } = require('../auth/helpers');
+
+const usersQueries = require('../queries/users');
+
+const processInput = require('../helpers/processInput');
+const handleError = require('../helpers/handleError');
+
+router.post('/add', async (request, response, next) => {
+    try {
+        if (request.user.a_id) {
+            const email = processInput(request.body.email, 'hardVC', 'user email', 50).toLowerCase();
+            const password = processInput(request.body.password, 'hardVC', 'user password');
+            const hashedPassword = await hashPassword(password);
+            
+            const newAdmin = await usersQueries.addUser(email, hashedPassword);
+            response.status(201).json({
+                error: false,
+                message: 'Successfully added new user to admin list',
+                payload: newAdmin,
+            });
+        }
+        else {
+            throw new Error("401__You don't permission to perform this operation - Admin right only");
+        }
+
+    } catch (err) {
+        handleError(err, request, response, next);
+    }
+})
+
+
+module.exports = router;

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -15,7 +15,8 @@ router.post('/add', async (request, response, next) => {
             const password = processInput(request.body.password, 'hardVC', 'user password');
             const hashedPassword = await hashPassword(password);
             
-            const newAdmin = await usersQueries.addUser(email, hashedPassword);
+            const newAdmin = await usersQueries.addUser(email, hashedPassword, 'admin');
+            delete newAdmin.password;
             response.status(201).json({
                 error: false,
                 message: 'Successfully added new user to admin list',
@@ -23,7 +24,7 @@ router.post('/add', async (request, response, next) => {
             });
         }
         else {
-            throw new Error("401__You don't permission to perform this operation - Admin right only");
+            throw new Error("401__You don't have permission to perform this operation - Admin right only");
         }
 
     } catch (err) {

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -203,7 +203,7 @@ const updateVolunteerUser = async (userId, request, response, next) => {
             if (request.file) {
                 storage.deleteFile(request.file.location);
             }
-            throw new Error('401__error: Wrong password');
+            throw new Error('401__Wrong password');
         }
         
     } catch (err) {
@@ -253,7 +253,7 @@ const updateFellowUser = async (userId, request, response, next) => {
             if (request.file) {
                 storage.deleteFile(request.file.location);
             }
-            throw new Error('401__error: Wrong password');
+            throw new Error('401__Wrong password');
         }
         
     } catch (err) {
@@ -306,7 +306,7 @@ const updatePassword = async(request, response, next) => {
             await usersQueries.updatePassword(loggedUserEmail, hashedPassword);
             next();
         } else {
-            throw new Error("401__error: Not authorized to update - password doesn't match or you don't have the right to update");
+            throw new Error("401__Not authorized to update - password doesn't match or you don't have the right to update");
         }
 
     } catch (err) {
@@ -340,11 +340,11 @@ const deleteAccount = async(request, response, next) => {
                 await fellowsQueries.deleteFellow(loggedUserId);
             }
     
-            // await usersQueries.deleteUser(loggedUserEmail)
+            // await usersQueries.deleteUser(loggedUserEmail);
             next();
         } 
         else {
-            throw new Error("401__error: Not authorized to delete");
+            throw new Error("401__Not authorized to delete");
         }
 
     } catch (err) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add more security on signing up a new user as Admin
## Description
<!--- Describe your changes in detail -->
An admin adds an email and default password to users_data to permit a new user to sign up as Admin
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adds a restriction for signing up a new user as Admin, for a user to be allowed to sign up as an Admin, thy must be registered (by an admin) into the users_data table (with an email and default password) then they can sign up providing their info, the default password and their new password
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Postman + Postico
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
