### PR TITLE
fix props not being passed bug in privateRouteGate, disable security redirect in privateRouteGate for now

### DIFF
--- a/frontend/src/Components/PrivateRouteGate.jsx
+++ b/frontend/src/Components/PrivateRouteGate.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { Route, Redirect } from 'react-router-dom';
 
 
-const PrivateRouteGate = ({ children, loggedUser, isUserStateReady }) => {
+const PrivateRouteGate = ({ children, loggedUser, isUserStateReady, ...rest }) => {
   // without this showInside, logout is visibly delayed for fraction of a second before redirect
   let showInside = null;
   if (isUserStateReady) {
@@ -19,16 +19,18 @@ const PrivateRouteGate = ({ children, loggedUser, isUserStateReady }) => {
 
   return (
     <Route
+      {...rest}
       render={({location}) =>
         loggedUser && (loggedUser.a_id || loggedUser.f_id || loggedUser.v_id)
           ? ( showInside )
-          : ( <Redirect
-                to={{
-                  pathname: "/",
-                  state: { from: location }
-                }}
-              />
-            )
+          : null
+          // : ( <Redirect
+          //       to={{
+          //         pathname: "/",
+          //         state: { from: location }
+          //       }}
+          //     />
+          //   )
       }
     />
   );


### PR DESCRIPTION
## Description
fix props not being passed bug in privateRouteGate, disable security redirect in privateRouteGate for now

## Motivation and Context
...rest var in component somehow missing => replaced, ternary in privateRouteGate is persistently evaling to false for unknown reason

## How Has This Been Tested?
browser url manipulating, and in browser visits

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings