### PR TITLE
fix broken delete event from modal bug

### DIFF
--- a/frontend/src/Components/Dashboards/DashboardAdmin.jsx
+++ b/frontend/src/Components/Dashboards/DashboardAdmin.jsx
@@ -42,8 +42,8 @@ const DashboardAdmin = (props) => {
 
 
     const hideEvent = () => {
-        setTargetEvent({});
         setShowEvent(false);
+        setTargetEvent({});
     };
 
 
@@ -83,7 +83,7 @@ const DashboardAdmin = (props) => {
                     setFeedback={setFeedback}
                     reloadParent={reloadDashboard}
                     setReloadParent={setReloadDashboard}
-                    // hideEvent={hideEvent}
+                    hideEvent={hideEvent}
                   />
                 : null
             }

--- a/frontend/src/Components/Dashboards/DashboardVolunteers.jsx
+++ b/frontend/src/Components/Dashboards/DashboardVolunteers.jsx
@@ -71,7 +71,7 @@ const DashboardVolunteers = (props) => {
                 setFeedback={setFeedback}
                 reloadParent={reloadDashboard}
                 setReloadParent={setReloadDashboard}
-                // hideEvent={hideEvent}
+                hideEvent={hideEvent}
               />
             : null
         }

--- a/frontend/src/Components/Events.jsx
+++ b/frontend/src/Components/Events.jsx
@@ -54,8 +54,8 @@ export default function EventSearch(props) {
 
  
     const hideEvent = () => {
-        setTargetEvent({});
         setShowEvent(false);
+        setTargetEvent({});
     }
 
 
@@ -115,7 +115,7 @@ export default function EventSearch(props) {
                                 setFeedback={setFeedback}
                                 reloadParent={reload}
                                 setReloadParent={setReload}
-                                // hideEvent={hideEvent}
+                                hideEvent={hideEvent}
                             />
                         :   null
                 }


### PR DESCRIPTION
## Description
Reimplements prop hideEvent passing into EventCard from admin, volunteer dashboards, and events components.
Switch order setShowEvent and setTargetEvent within hideEvent function back to original.

## Motivation and Context
Clicking on Delete button from Admin dashboard or events sections modals caused undefined errors and missing function errors. Changes from a previous pr (#85) I made introduced said errors. This corrects those and repairs proper delete functionality

## How Has This Been Tested?
end-to-end check, deleting of events as admin and volunteer users

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings