### PR TITLE
fix links and Manage Mentoring button click on volunteer page primaryModals

### DIFF
--- a/frontend/src/Components/ProfilePages/VolunteerProfilePage.jsx
+++ b/frontend/src/Components/ProfilePages/VolunteerProfilePage.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import axios from 'axios';
 
-import { PMBody } from '../Modals/PrimaryModal';
+import { PMBody, PMFooter } from '../Modals/PrimaryModal';
 
 export default function VolunteerProfilePage(props) {
     const history = useHistory();
@@ -102,108 +102,136 @@ export default function VolunteerProfilePage(props) {
         <>
             {
                 waitingForData
-                ?   null // OR it can be a spinner 
-                :   !profilePublic 
-                    ? <h3 className='text-center'>Sorry, nothing to show</h3>
-                    // : <div className='row p-3'>
-                    : <PMBody>
-                        {
-                            volunteer.deleted
-                            ? <div className='col-12 bg-warning text-white text-center'>This volunteer has left the platform</div>
-                            : null
-                        }
-
-                        <div className='col-sm-6'>
-                            <img 
-                                className='d-block w-100'
-                                src={volunteer.v_picture || '/images/default_pic.png'} 
-                                alt={`${volunteer.v_first_name} ${volunteer.v_last_name}`}
-                            />
-                            <span className='d-block'><strong>Volunteered Hours: </strong>{volunteer.total_hours}</span>
-                        </div>
-
-                        <div className='col-sm-6'>
-                            <span className='d-block h3'>{`${volunteer.v_first_name} ${volunteer.v_last_name}`}</span>
-                            <a className='d-block' href={`mailto:${volunteer.v_email}`} target='_blank' rel='noopener noreferrer'>
-                                {volunteer.v_email} 
-                            </a>
-                            <span className='d-block'><strong>Company: </strong>{volunteer.company}</span>
-                            <span className='d-block'><strong>Title: </strong>{volunteer.title}</span>
-                            <div className='row'>
-                                <div className='col-sm-4'>Skills:</div>
-                                <div className='col-sm-8'>
-                                    { volunteer.skills
-                                        ? volunteer.skills.map((skill, index) => <span className='d-block' key={skill+index}>{skill}</span>)
-                                        : null
-                                    }   
-                                </div>
-                            </div>
-                        </div>
-
-                        <div className='col-sm-12'>
-                            <span className='d-block'><strong>LinkedIn: </strong>{volunteer.v_linkedin}</span>
-                            <span className='d-block'><strong>Bio: </strong>{volunteer.v_bio}</span>
-
-                            <div className='col-sm-12 d-flex flex-wrap justify-content-start'>
-                                <strong className='d-block mx-2'>Interested in: </strong>
+                    ?   null // OR it can be a spinner
+                    :   !profilePublic
+                        ? <h3 className='text-center'>Sorry, nothing to show</h3>
+                        // : <div className='row p-3'>
+                        : <>
+                            <PMBody>
                                 {
-                                    tasks.map((interest, index) => 
-                                        <span key={index + interest[0]} className='d-block mx-2'>
-                                            {interest[0]}
-                                        </span>
-                                    )          
-                                }  
-                            </div>
-
-                            <div className='d-flex flex-wrap justify-content-start'>
-                                <strong className='d-block mx-2'>Mentoring: </strong>
-                                {
-                                    mentees.map(mentee => 
-                                        <span key={mentee[0] + mentee[1] + mentee[2]} className='d-block mx-2' 
-                                            onClick={e => history.push(`/fellow/${mentee[0]}`)}>
-                                            {mentee[1]}
-                                        </span>
-                                    )          
-                                }
-
-                                {
-                                    props.loggedUser && props.loggedUser.a_id && openToMentor
-                                    ?   <button className='btn btn-primary' 
-                                            onClick={e => history.push(`/mentoring/volunteer/${volunteer.v_id}`)}>
-                                            Manage Mentoring
-                                        </button>
+                                    volunteer.deleted
+                                    ? <div className='col-12 bg-warning text-white text-center'>This volunteer has left the platform</div>
                                     : null
                                 }
-                            </div>
 
-                            <div className='row'>
-                                <ul className='plainUl col-sm-6'><strong>Past Events: </strong>
-                                {
-                                    pastEvents.map(event => 
-                                        <li key={event[0] + event[1] + event[2]} className='d-block mx-2'
-                                            onClick={e => history.push(`/event/${event[0]}`)}>
-                                            {event[1]} ({new Date(event[2]).toLocaleDateString()}) - 
-                                            { event[4] ? <span> {event[4]} hours</span> : <span>Hours not assigned yet</span> }
-                                        </li>
-                                    )          
-                                } 
-                                </ul>
-                                <ul className='plainUl col-sm-6'><strong>Current / Upcoming Events: </strong>
-                                {
-                                    events.map(event => 
-                                        <span key={event[0] + event[1] + event[2]} className='d-block mx-2'
-                                            onClick={e => history.push(`/event/${event[0]}`)}>
-                                            {event[1]} ({new Date(event[2]).toLocaleDateString()})
-                                        </span>
-                                    )          
-                                }
-                                </ul> 
-                            </div>
-                        </div>
-                    </PMBody>
-                    // </div>
+                                <div className='col-12'>
+                                    <img
+                                        className='g1ProfilePic d-block'
+                                        src={volunteer.v_picture || '/images/default_pic.png'}
+                                        alt={`${volunteer.v_first_name} ${volunteer.v_last_name}`}
+                                    />
+
+                                    <span className='d-block h3 mb-0'>{`${volunteer.v_first_name} ${volunteer.v_last_name}`}</span>
+                                    <a className='d-block' href={`mailto:${volunteer.v_email}`} target='_blank' rel='noopener noreferrer'>
+                                        {volunteer.v_email}
+                                    </a>
+                                    <span className='d-block'><strong>LinkedIn: </strong>{volunteer.v_linkedin}</span>
+
+                                    <span className='d-block'><strong>Company: </strong>{volunteer.company}</span>
+                                    <span className='d-block'><strong>Title: </strong>{volunteer.title}</span>
+
+                                    <span className='d-block mb-3'><strong>Volunteered Hours: </strong>{volunteer.total_hours}</span>
+
+                                    <div className='row'>
+                                        <div className='col'><strong>Skills: </strong></div>
+                                        <div className='col'>
+                                            { volunteer.skills
+                                                ? volunteer.skills.map((skill, index) => <span className='d-block' key={skill+index}>{skill}</span>)
+                                                : null
+                                            }
+                                        </div>
+                                    </div>
+
+                                    <span className='d-block'><strong>Bio: </strong>{volunteer.v_bio}</span>
+
+                                    <div className='col-sm-12 d-flex flex-wrap justify-content-start'>
+                                        <strong className='d-block mx-2'>Interested in: </strong>
+                                        {
+                                            tasks.map((interest, index) =>
+                                                <span key={index + interest[0]} className='d-block mx-2'>
+                                                    {interest[0]}
+                                                </span>
+                                            )
+                                        }
+                                    </div>
+
+                                    <div className='d-flex flex-wrap justify-content-start'>
+                                        <strong className='d-block mx-2'>Mentoring: </strong>
+                                        {
+                                            mentees.map(mentee =>
+                                                <Link
+                                                    key={mentee[0] + mentee[1] + mentee[2]}
+                                                    className='d-block mx-2'
+                                                    to={`/fellow/${mentee[0]}`}
+                                                    target="_blank"
+                                                >
+                                                    {mentee[1]}
+                                                </Link>
+                                                // <span key={mentee[0] + mentee[1] + mentee[2]} className='d-block mx-2'
+                                                //     data-dismiss='modal'
+                                                //     onClick={e => history.push(`/fellow/${mentee[0]}`)}>
+                                                //     {mentee[1]}
+                                                // </span>
+                                            )
+                                        }
+
+                                        {
+                                            props.loggedUser && props.loggedUser.a_id && openToMentor
+                                            ?   <button className='btn btn-info'
+                                                    data-dismiss='modal'
+                                                    onClick={e => history.push(`/mentoring/volunteer/${volunteer.v_id}`)}>
+                                                    Manage Mentoring
+                                                </button>
+                                            : null
+                                        }
+                                    </div>
+
+                                    <div className='row'>
+                                        <ul className='plainUl col-sm-6'><strong>Past Events: </strong>
+                                        {
+                                            pastEvents.map(event =>
+                                                <Link
+                                                    key={event[0] + event[1] + event[2]}
+                                                    className='d-block mx-2'
+                                                    to={`/event/${event[0]}`}
+                                                    target="_blank"
+                                                >
+                                                    {event[1]} ({new Date(event[2]).toLocaleDateString()}) -
+                                                    { event[4] ? <span> {event[4]} hours</span> : <span>Hours not assigned yet</span> }
+                                                </Link>
+                                                // <li key={event[0] + event[1] + event[2]} className='d-block mx-2'
+                                                //     onClick={e => history.push(`event/${event[0]}`)}>
+                                                //     {event[1]} ({new Date(event[2]).toLocaleDateString()}) -
+                                                //     { event[4] ? <span> {event[4]} hours</span> : <span>Hours not assigned yet</span> }
+                                                // </li>
+                                            )
+                                        }
+                                        </ul>
+                                        <ul className='plainUl col-sm-6'><strong>Current / Upcoming Events: </strong>
+                                        {
+                                            events.map(event =>
+                                                <Link
+                                                    key={event[0] + event[1] + event[2]}
+                                                    className='d-block mx-2'
+                                                    to={`/event/${event[0]}`}
+                                                    target="_blank"
+                                                >
+                                                    {event[1]} ({new Date(event[2]).toLocaleDateString()})
+                                                </Link>
+                                                // <span key={event[0] + event[1] + event[2]} className='d-block mx-2'
+                                                //     onClick={e => history.push(`event/${event[0]}`)}>
+                                                //     {event[1]} ({new Date(event[2]).toLocaleDateString()})
+                                                // </span>
+                                            )
+                                        }
+                                        </ul>
+                                    </div>
+                                </div>
+                            </PMBody>
+                            <PMFooter className='g1NonAdminFooter' />
+                        </>
+                        // </div>
             }
-
         </>
     )
 }


### PR DESCRIPTION
## Description
On Volunteers page, for admin user, the modal dismiss attribute was added to the Manage Mentoring button to correctly dismiss the modal shade on click. Also the mapped fellow mentees links, events past and upcoming links were all converted to react-router Links that open in new tabs (target='_blank')

## Motivation and Context
The manage mentoring button needs to dismiss the modal shade otherwise it persists and obscures the page from even clicking until reload.
The links were converted to react-router Links because opening a second modal would look cluttered as well as right clicking the original spans would not give the proper options for browser links aka bad UX. Perhaps in future clicking one of these links in the primary modal would only switch the content of the primaryModal -  but that is to be decided and work for another day.

## How Has This Been Tested?
end-to-end testing in browsers

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings